### PR TITLE
feat: update accordion with biblical verses and orange styling

### DIFF
--- a/src/components/accordion/accordion.css
+++ b/src/components/accordion/accordion.css
@@ -27,6 +27,19 @@
   align-items: center;
   text-align: start;
   cursor: pointer;
+  background-color: #FF6B35;
+  border-radius: var(--radius-large);
+  padding: var(--padding-small);
+  color: white;
+  transition: background-color 0.3s ease;
+}
+
+.accordion-header:hover {
+  background-color: #e55a2b;
+}
+
+.accordion-item.active .accordion-header {
+  background-color: #d64e20;
 }
 
 .accordion-header h3 {
@@ -47,9 +60,10 @@
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 50%;
-  color: var(--color-background-dark);
+  color: white;
   cursor: pointer;
-  border: 2px solid var(--color-border);
+  border: 2px solid white;
+  background-color: rgba(255, 255, 255, 0.2);
 }
 
 .accordion-content {

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -15,7 +15,7 @@ export const accordionItems: Item[] = [
     id: "01",
     title: "VERSÍCULOS",
     content:
-      "<strong>Versículos bíblicos que o Senhor já falou comigo e que marcaram meu relacionamento com ele.</strong> <br />Os versículos que Deus já falou sobre você, são pilares para sustentar a sua jornada.",
+      "<strong>Josué 1:8</strong> - \"Não cesse de falar deste Livro da Lei; antes, medita nele dia e noite, para que tenhas cuidado de fazer segundo tudo quanto nele está escrito; então, farás prosperar o teu caminho e serás bem-sucedido.\"<br /><br /><strong>3 João 1:2</strong> - \"Amado, desejo que te vá bem em todas as coisas e que tenhas saúde, assim como bem vai a tua alma.\"<br /><br /><strong>Provérbios 16:3</strong> - \"Entrega ao Senhor as tuas obras, e os teus pensamentos serão estabelecidos.\"",
   },
   {
     id: "02",


### PR DESCRIPTION
This PR updates the "01 VERSÍCULOS" section in the "CONSTRUINDO MINHA BIG PICTURE" accordion component:

## Changes:
- Replace placeholder content with 3 specific biblical verses about prosperity
- Add orange background (#FF6B35) to accordion headers
- Include hover and active states for orange theme
- Update icon styling for better contrast

## Biblical Verses Added:
1. **Josú 1:8**
2. **3 João 1:2**
3. **Provérbios 16:3**

Fixes #1

Generated with [Claude Code](https://claude.ai/code)